### PR TITLE
chore: update azd CLI action to version 2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install azd CLI
-        uses: Azure/setup-azd@v1.0.0
+        uses: Azure/setup-azd@v2
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
This pull request makes a minor update to the continuous deployment workflow configuration. The main change is upgrading the Azure CLI setup action to a newer version.